### PR TITLE
Add an option to automatically number BASIC

### DIFF
--- a/autonum.js
+++ b/autonum.js
@@ -1,0 +1,74 @@
+// Automatically numbers unnumbered lines.
+// Supports GOTO Label
+
+function AutomaticNumbering(contents, step) {
+  const numbers = []
+  const commands = []
+  const labels = {}  // str => line number
+  var num = 0
+  if (!step) {
+    step = 1
+  }
+
+  const raw = contents.split("\n")
+  for (var i = 0; i < raw.length; i++) {
+    /** @type {string} */
+    var line = raw[i]
+    if (line.trim() === "") {
+      numbers.push("")
+      commands.push(line)
+      continue
+    }
+
+    const existing = line.match(/^(\d\d*)(.*)/)
+    if (existing) {
+      num = parseInt(existing[1])
+      line = existing[2]
+    }
+
+    numbers.push(num)
+    commands.push(line)
+
+    const match = line.match(/^REM ([^:]*):$/)
+    if (match) {
+      labels[match[1]] = num
+    }
+
+    num += step
+  }
+
+  var result = ""
+
+  const labelRef = "(GOTO|GOSUB) ([a-zA-Z][a-zA-Z0-9_\-]*)"
+  for (var i = 0; i < numbers.length; i++) {
+    const line = numbers[i]
+    var command = commands[i]
+    const matches = command.match(new RegExp(labelRef, "g"))
+    if (!matches) {
+      result += line + " " + command + "\n"
+      continue
+    }
+
+    var comments = []
+
+    for (var j = 0; j < matches.length; j++) {
+      const match = matches[j].match(new RegExp(labelRef))
+      const number = labels[match[2]]
+      const label = match[2]
+      command = command.replace(label, number)
+      comments.push(match[1] + " " + label)
+    }
+
+    result += line + " " + command + " : REM " + comments.join(" : ") + "\n"
+  }
+
+  return result
+}
+
+if (typeof module !== "undefined") {
+  // NodeJS
+  const fs = require("fs")
+  const contents = fs.readFileSync(process.stdin.fd)
+  const result = AutomaticNumbering(contents.toString(), 1)
+  console.log(result)
+}

--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@ By <a target=_blank href="mailto:inexorabletash@gmail.com">Joshua Bell</a>
 
   <button id="show_paper" title="Echo all output to a &quot;print-out&quot;, so you can copy/paste">&#x1F4C3; Show output</button>
   <button id="hide_paper" title="Hide the &quot;print-out&quot;">&#x1F6AB; Hide output</button>
+
+  <input type="checkbox" id="autonum">Automatic-Numbering
   </form>
 
 </div>
@@ -153,6 +155,8 @@ By <a target=_blank href="mailto:inexorabletash@gmail.com">Joshua Bell</a>
   <li><a target="_blank" href="http://www.6502asm.com/">6502asm.com</a> - a 6502 assembler/emulator in JavaScript
   <li><a target="_blank" href="http://www.quitebasic.com/">Quite BASIC</a> - a similar project aimed at teaching programming
 </ul>
+
+<output style="font-family: monospace; font-size: small"></output>
 
 <div id="paper-spacer"></div>
 <div id="paper"></div>

--- a/index.html
+++ b/index.html
@@ -165,4 +165,5 @@ By <a target=_blank href="mailto:inexorabletash@gmail.com">Joshua Bell</a>
 <script src="hires.js"></script>
 <script src="dos.js"></script>
 <script src="printer.js"></script>
+<script src="autonum.js"></script>
 <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -114,7 +114,12 @@ window.addEventListener('DOMContentLoaded', function() {
 
     try {
       var source = getSource()
-      source = AutomaticNumbering(source)
+
+      $('output').innerText = ''
+      if ($('#autonum').checked) {
+        source = AutomaticNumbering(source)
+        $('output').innerText = source
+      }
 
       program = basic.compile(source);
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,10 @@ window.addEventListener('DOMContentLoaded', function() {
     tty.autoScroll = true;
 
     try {
-      program = basic.compile(getSource());
+      var source = getSource()
+      source = AutomaticNumbering(source)
+
+      program = basic.compile(source);
     } catch (e) {
       if (e instanceof basic.ParseError) {
         editor.setCursor({ line: e.line - 1, ch: e.column - 1 });


### PR DESCRIPTION
These changes add an optional enhancement that will automatically number lines with support for labels.

Labels are declared using the form `REM Label:` and can be used in `GOTO` and `GOSUB`.

The visual changes are:
1. Checkbox labelled `Automatic-Numbering`.
2. Numbered BASIC written to an `<output>`, helpful during debugging.

![Screenshot of new checkbox](https://user-images.githubusercontent.com/1855194/68000091-135f7500-fc35-11e9-9ce2-39019947ca81.png)
